### PR TITLE
Use rdf-normlize

### DIFF
--- a/cmp.rb
+++ b/cmp.rb
@@ -1,6 +1,6 @@
 require 'rdf'
 require 'linkeddata'
-require 'rdf/nquads'
+require 'rdf/normalize'
 
 file1 = "test1"
 file2 = "test2"
@@ -10,31 +10,33 @@ graph1 = RDF::Graph.load(file1 + ".ttl")
 graph2 = RDF::Graph.load(file2 + ".ttl")
 
 puts "canon'ing graphs"
-graphc1 = graph1.canonicalize()
-graphc2 = graph2.canonicalize()
+graphc1 = graph1.dump(:normalize)
+graphc2 = graph2.dump(:normalize)
 
-puts "|graphc1| = " + graphc1.count().to_s
-puts "|graphc2| = " + graphc2.count().to_s
+graphc1_triples = graphc1.split("\n")
+graphc2_triples = graphc1.split("\n")
+puts "|graphc1| = #{graphc1_triples.length}"
+puts "|graphc2| = #{graphc2_triples.length}"
 
-File.open("canon/" + file1 + ".nq", "w") { |f| f.write(graphc1.dump(:nquads)) }
-File.open("canon/" + file2 + ".nq", "w") { |f| f.write(graphc2.dump(:nquads)) }
+File.open("canon/" + file1 + ".nq", "w") { |f| f.write(graphc1) }
+File.open("canon/" + file2 + ".nq", "w") { |f| f.write(graphc2) }
 
 puts "\nmissing in graph2:"
 miss2_cnt = 0
-graph1.each_statement do |stmt|
-    if !graph2.statement?(stmt)
+graphc1_triples.each do |triple|
+    if !graphc2.include?(triple)
         miss2_cnt += 1
-        puts stmt
+        puts triple
     end
 end
-puts "# missing in graph2: " + miss2_cnt.to_s
+puts "# missing in graph2: #{miss2_cnt}"
 
 puts "\nmissing in graph1:"
 miss1_cnt = 0
-graph2.each_statement do |stmt|
-    if !graph1.statement?(stmt)
+graphc2_triples.each do |triple|
+    if !graphc1.include?(triple)
         miss1_cnt += 1
-        puts stmt
+        puts triple
     end
 end
-puts "# missing in graph1: " + miss1_cnt.to_s
+puts "# missing in graph1: #{miss1_cnt}"


### PR DESCRIPTION
The proper way to generate canonical output is using `graph.dump(:normalize)`.

The RDF documentation for the `#canonicalize` method should be updated to avoid confusion, and potentially defer to the rdf-normalize gem, if loaded. Additionally, the `:canonicalize` dump format should be added. In the mean time, I think this accomplishes what you want. There's probably a better diff method to use, though.